### PR TITLE
Identity module unit tests

### DIFF
--- a/blockchain/x/identity/keeper/keeper_test.go
+++ b/blockchain/x/identity/keeper/keeper_test.go
@@ -1,0 +1,32 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+type memStoreKey struct {
+	kv map[string]string
+}
+
+func newMemoryStoreKey() *memStoreKey {
+	kv := make(map[string]string)
+	return &memStoreKey{kv: kv}
+}
+
+func (m memStoreKey) Name() string {
+	return "storeKey"
+}
+
+func (m memStoreKey) String() string {
+	return "storeKey"
+}
+
+func Test_NewKeeper(t *testing.T) {
+	if k := NewKeeper(nil, newMemoryStoreKey(), newMemoryStoreKey(),
+		types.NewSubspace(nil, nil, newMemoryStoreKey(), newMemoryStoreKey(), "subspace"),
+		nil); k == nil {
+		t.Fatal("expeced non-nil struct")
+	}
+}

--- a/blockchain/x/identity/keeper/workspace_test.go
+++ b/blockchain/x/identity/keeper/workspace_test.go
@@ -1,0 +1,7 @@
+package keeper
+
+import "testing"
+
+func Test_WorkSpace(t *testing.T) {
+	// TODO
+}


### PR DESCRIPTION
Work in progress. The aim is to increase the unit test code coverage module by module starting with `/x/identity`.