### PR TITLE
chore(mpc-relayer): use thread channel to handle graceful shutdown.

### DIFF
--- a/mpc-relayer/Makefile
+++ b/mpc-relayer/Makefile
@@ -5,7 +5,7 @@
 
 test:
 	@echo "Running tests..."
-	@ go test -cover ./...	
+	@ go test -cover -race ./...	
 
 build:
 	@cd cmd/mpc-relayer && ./build_static.sh && mv mpc-relayer ../../bin/mpc-relayer

--- a/mpc-relayer/pkg/service/key_request_handler_test.go
+++ b/mpc-relayer/pkg/service/key_request_handler_test.go
@@ -34,7 +34,7 @@ func (m mockTxClient) RejectSignatureRequest(ctx context.Context, requestID uint
 	return nil
 }
 
-func Test_KeyControllerStart(t *testing.T) {
+func Test_KeyControllerStartStop(t *testing.T) {
 	k := testSetupKeyController(t)
 	if err := k.Start(); err != nil {
 		t.Fatal(err)

--- a/mpc-relayer/pkg/service/utils.go
+++ b/mpc-relayer/pkg/service/utils.go
@@ -21,6 +21,8 @@ var (
 	defaultChanSize = 1000
 
 	defaultPageLimit uint64 = 10
+
+	defaultThreads = 6
 )
 
 func requeueKeyItemWithTimeout(c chan *keyRequestQueueItem, item *keyRequestQueueItem, timeout time.Duration) {
@@ -37,4 +39,12 @@ func requeueSigItemWithTimeout(c chan *signatureRequestQueueItem, item *signatur
 		item.retries++
 		c <- item
 	}()
+}
+
+func makeThreads(n int) chan struct{} {
+	t := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		t <- struct{}{}
+	}
+	return t
 }


### PR DESCRIPTION
This improves upon the initial version of the mpc-relayer shutdown routine implemented in #101.
 
The initial version used a variable `processing` that blocked the process executor from returning and could be altered by one or more goroutines. The logic has been altered to make use of a thread channel, reducing data race error risk.

The change also caps the number of goroutines that can make RPC queries at any one time.