### PR TITLE
perf(web): speed up Explorer page

### DIFF
--- a/web/src/client/chain.ts
+++ b/web/src/client/chain.ts
@@ -87,13 +87,6 @@ export async function status(): Promise<RpcResponse<StatusResponse>> {
   return await rpcRequest<StatusResponse>("status", {});
 }
 
-export async function latestBlocks(count: number): Promise<BlockResponseParsed[]> {
-  const statusRes = await status();
-  const latestHeight = parseInt(statusRes.result.sync_info.latest_block_height, 10);
-  const res = await rpcRequest<BlockSearchResponse>("block_search", { query: `block.height>${latestHeight-count} AND block.height<=${latestHeight}`, "per_page": count?.toString() });
-  return res.result.blocks.map(parseBlockResponse);
-}
-
 export async function block(height: string | undefined) {
   const res = await rpcRequest<BlockResponse>("block", { height });
   return parseBlockResponse(res.result);


### PR DESCRIPTION
Apparently `block_search` queries are pretty expensive and don't scale with the chain growing. Instead we now run 10 parallel `block?height=XXX` that are supposed to be O(1) accesses.

On devnet `block_search` takes ~3 seconds, `block?height=XXX` takes 300ms.