### PR TITLE
test(keyring): Add bip44 benchmark tests

### DIFF
--- a/keyring/pkg/services/bip44kms/bip44_benchmark_test.go
+++ b/keyring/pkg/services/bip44kms/bip44_benchmark_test.go
@@ -1,0 +1,72 @@
+package kms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/qredo/fusionchain/keyring/pkg/mpc"
+)
+
+var cryptoTests = []struct {
+	name string
+	c    mpc.CryptoSystem
+}{
+	{
+		"ECDSA",
+		mpc.EcDSA,
+	},
+	{
+		"EdDSA",
+		mpc.EdDSA,
+	},
+}
+
+func Benchmark_CreateKey(b *testing.B) {
+	for _, tc := range bip44tests[0:2] {
+		keyIDStr := fmt.Sprintf("0x%0*x", keyIDLength, tc.keyID)
+		id := hexutil.MustDecode(keyIDStr)
+		b.Run(tc.name, func(b *testing.B) {
+			for _, tt := range cryptoTests {
+				b.Run(tt.name, func(b *testing.B) {
+					k, err := NewBip44KeyRing(testMnemonic, "password", tt.c)
+					if err != nil {
+						b.Fatal(err)
+					}
+					for i := 0; i < b.N; i++ {
+						if _, err := k.PublicKey(id); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+
+	}
+}
+
+func Benchmark_CreateSig(b *testing.B) {
+	for _, tc := range bip44tests[0:2] {
+		keyIDStr := fmt.Sprintf("0x%0*x", keyIDLength, tc.keyID)
+		id := hexutil.MustDecode(keyIDStr)
+		b.Run(tc.name, func(b *testing.B) {
+			for _, tt := range cryptoTests {
+				k, err := NewBip44KeyRing(testMnemonic, "password", tt.c)
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.Run(tt.name, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						if _, _, err := k.Signature(&mpc.SigRequestData{
+							KeyID:   id,
+							ID:      id,
+							SigHash: testECDSASigHash[:],
+						}); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add some crypto benchmarks to the BIP44 KMS package.

```
goos: linux
goarch: amd64
pkg: github.com/qredo/fusionchain/keyring/pkg/services/bip44kms
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
Benchmark_CreateKey/min/ECDSA-20            7694            153044 ns/op            7810 B/op         97 allocs/op
Benchmark_CreateKey/min/EdDSA-20           21192             57448 ns/op            6607 B/op         76 allocs/op
Benchmark_CreateKey/max/ECDSA-20            7815            153322 ns/op            7885 B/op         99 allocs/op
Benchmark_CreateKey/max/EdDSA-20           20966             56881 ns/op            6682 B/op         78 allocs/op
Benchmark_CreateSig/min/ECDSA-20            5175            230394 ns/op            8224 B/op        102 allocs/op
Benchmark_CreateSig/min/EdDSA-20            9656            114443 ns/op            6786 B/op         77 allocs/op
Benchmark_CreateSig/max/ECDSA-20            4353            232312 ns/op            8301 B/op        104 allocs/op
Benchmark_CreateSig/max/EdDSA-20           10452            114896 ns/op            6861 B/op         79 allocs/op
PASS
ok      github.com/qredo/fusionchain/keyring/pkg/services/bip44kms      14.127s
```