### PR TITLE
fix: enforce 32bytes for sig request

### DIFF
--- a/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
+++ b/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
@@ -21,7 +21,7 @@ func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewS
 		return nil, fmt.Errorf("key not found")
 	}
 
-	if len(msg.DataForSigning) != 32 && key.Type == 1 {
+	if len(msg.DataForSigning) != 32 && key.Type == types.KeyType_KEY_TYPE_ECDSA_SECP256K1 {
 		return nil, fmt.Errorf("signed data is not 32 bytes. Length is: %d", len(msg.DataForSigning))
 	}
 

--- a/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
+++ b/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
@@ -21,6 +21,10 @@ func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewS
 		return nil, fmt.Errorf("key not found")
 	}
 
+	if len(msg.DataForSigning) != 32 {
+		return nil, fmt.Errorf("signed data is not 32 bytes. Length is: %d", len(msg.DataForSigning))
+	}
+
 	ws := k.identityKeeper.GetWorkspace(ctx, key.WorkspaceAddr)
 	if ws == nil {
 		return nil, fmt.Errorf("workspace not found")

--- a/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
+++ b/blockchain/x/treasury/keeper/msg_server_new_signature_request.go
@@ -21,7 +21,7 @@ func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewS
 		return nil, fmt.Errorf("key not found")
 	}
 
-	if len(msg.DataForSigning) != 32 {
+	if len(msg.DataForSigning) != 32 && key.Type == 1 {
 		return nil, fmt.Errorf("signed data is not 32 bytes. Length is: %d", len(msg.DataForSigning))
 	}
 


### PR DESCRIPTION
This pull requests enforces that the data to be signed in a signature request has 32 bytes. If it doesn't the transaction fails