### PR TITLE
fix(blockchain): fusiond info cmd

### DIFF
--- a/blockchain/Makefile
+++ b/blockchain/Makefile
@@ -62,15 +62,15 @@ build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=fusion \
-		  -X github.com/cosmos/cosmos-sdk/version.AppName=$(NODE_BINARY) \
-		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+ldflags = -X "github.com/cosmos/cosmos-sdk/version.Name=fusion" \
+		  -X "github.com/cosmos/cosmos-sdk/version.AppName=$(NODE_BINARY)" \
+		  -X "github.com/cosmos/cosmos-sdk/version.Version=$(VERSION)" \
+		  -X "github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT)" \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
-		  -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TMVERSION) \
-	      -X "github.com/qredo/fusionchain/blockchain/version.linkedDate=$(VERSION_DATE)" \
-		  -X "github.com/qredo/fusionchain/blockchain/version.linkedSemVer=$(VERSION)" \
-		  -X "github.com/qredo/fusionchain/blockchain/version.linkedCommit=$(COMMIT)" 
+		  -X "github.com/tendermint/tendermint/version.TMCoreSemVer=$(TMVERSION)" \
+	      -X "github.com/qredo/fusionchain/version.linkedDate=$(VERSION_DATE)" \
+		  -X "github.com/qredo/fusionchain/version.linkedSemVer=$(VERSION)" \
+		  -X "github.com/qredo/fusionchain/version.linkedCommit=$(COMMIT)" 
 
 # DB backend selection
 ifeq (cleveldb,$(findstring cleveldb,$(COSMOS_BUILD_OPTIONS)))

--- a/blockchain/Makefile
+++ b/blockchain/Makefile
@@ -68,7 +68,9 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=fusion \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
 		  -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TMVERSION) \
-	      -X "github.com/qredo/fusionchain/blockchain/version.linkedDate=$(VERSION_DATE)"
+	      -X "github.com/qredo/fusionchain/blockchain/version.linkedDate=$(VERSION_DATE)" \
+		  -X "github.com/qredo/fusionchain/blockchain/version.linkedSemVer=$(VERSION)" \
+		  -X "github.com/qredo/fusionchain/blockchain/version.linkedCommit=$(COMMIT)" 
 
 # DB backend selection
 ifeq (cleveldb,$(findstring cleveldb,$(COSMOS_BUILD_OPTIONS)))

--- a/blockchain/cmd/fusiond/root.go
+++ b/blockchain/cmd/fusiond/root.go
@@ -62,7 +62,7 @@ import (
 	fusionchain "github.com/qredo/fusionchain/types"
 )
 
-const EnvPrefix = "ETHERMINT"
+const EnvPrefix = "FUSION"
 
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.

--- a/blockchain/version/version.go
+++ b/blockchain/version/version.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -51,17 +50,6 @@ var CommitHash = func() string {
 // SemanticVersion returns the semantic version
 // https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
 var SemanticVersion = func() string {
-	// Permitted tag formats
-	//
-	// "fusiond@1.0.0" OR "1.0.0"
-	//
-	if strings.Contains(linkedSemVer, "fusiond") {
-		strs := strings.Split(linkedSemVer, "@")
-		if len(strs) != 2 {
-			panic(fmt.Sprintf("unexpected server string, got %v", linkedSemVer))
-		}
-		return strs[1]
-	}
 	if linkedSemVer != "" {
 		return linkedSemVer
 	}

--- a/blockchain/version/version.go
+++ b/blockchain/version/version.go
@@ -14,20 +14,21 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
-	AppVersion = "0.0.0"
-	GitCommit  = ""
-	BuildDate  = ""
-	GoVersion  = ""
-	GoArch     = ""
+	GitCommit = ""
+	BuildDate = ""
+	GoVersion = ""
+	GoArch    = ""
 
 	linkedCommit string // overwritten by -ldflag "-X 'github.com/qredo/fusionchain/blockchain/version.linkedCommit=$commit_hash'"
 	linkedDate   string // overwritten by -ldflag "-X 'github.com/qredo/fusionchain/blockchain/version.linkedDate=$build_date'"
+	linkedSemVer string // overwritten by -ldflag "-X 'github.com/qredo/fusionchain/blockchain/version.linkedSemVer=$semantic_version'"
 )
 
 // CommitHash returns the first 8 characters of the git commit hash
@@ -47,6 +48,23 @@ var CommitHash = func() string {
 	return "00000000"
 }()
 
+// SemanticVersion returns the semantic version
+// https://icinga.com/blog/2022/05/25/embedding-git-commit-information-in-go-binaries/
+var SemanticVersion = func() string {
+	// Permitted tag formats
+	//
+	// "fusiond@1.0.0" OR "1.0.0"
+	//
+	if strings.Contains(linkedSemVer, "fusiond") {
+		strs := strings.Split(linkedSemVer, "@")
+		if len(strs) != 2 {
+			panic(fmt.Sprintf("unexpected server string, got %v", linkedSemVer))
+		}
+		return strs[1]
+	}
+	return "0.0.0"
+}()
+
 // Date returns the compilation build time
 var Date = func() string {
 	if linkedDate != "" {
@@ -56,8 +74,8 @@ var Date = func() string {
 }()
 
 func init() {
-	if len(AppVersion) == 0 {
-		AppVersion = "dev"
+	if len(SemanticVersion) == 0 {
+		SemanticVersion = "0.0.0"
 	}
 
 	GoVersion = runtime.Version()
@@ -69,7 +87,7 @@ func init() {
 func Version() string {
 	return fmt.Sprintf(
 		"Version %s (GitCommit %s)\nCompiled at %s using Go %s (%s)",
-		AppVersion,
+		SemanticVersion,
 		GitCommit,
 		BuildDate,
 		GoVersion,

--- a/blockchain/version/version.go
+++ b/blockchain/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	AppVersion = "1.1.2"
+	AppVersion = "0.0.0"
 	GitCommit  = ""
 	BuildDate  = ""
 	GoVersion  = ""

--- a/blockchain/version/version.go
+++ b/blockchain/version/version.go
@@ -62,6 +62,9 @@ var SemanticVersion = func() string {
 		}
 		return strs[1]
 	}
+	if linkedSemVer != "" {
+		return linkedSemVer
+	}
 	return "0.0.0"
 }()
 

--- a/docker/Dockerfile-fusiond
+++ b/docker/Dockerfile-fusiond
@@ -15,13 +15,15 @@ ARG ARCH=x86_64
 ARG BUILD_DATE
 ARG GIT_SHA
 ARG SERVICE
+ARG VERSION
 
 # Set env variables
 ENV arch=$ARCH
 ENV build_date=$BUILD_DATE
 ENV commit_hash=$GIT_SHA
 ENV service_name=$SERVICE
-RUN echo "building service: ${service_name}, build date: ${build_date}, commit hash: ${commit_hash}, architecture: ${arch}"
+ENV version=$VERSION
+RUN echo "building service: ${service_name}, version: ${version}, build date: ${build_date}, commit hash: ${commit_hash}, architecture: ${arch}"
 
 # Add libwasmvm for musl
 # Run `grep wasmvm go.mod` to find the version used in the project.

--- a/docker/docker-build-fusiond.sh
+++ b/docker/docker-build-fusiond.sh
@@ -5,6 +5,7 @@ set -e
 # Version control
 commit_hash=$(git rev-parse HEAD)
 commit_hash_short=$(git rev-parse --short HEAD)
+version_tag=$(git describe --abbrev=0 --tags)
 
 # Set ARCH variable based on the architecture
 architecture=$(uname -m)
@@ -21,6 +22,7 @@ docker build \
        --build-arg BUILD_DATE="$(git show -s --format=%ci $commit_hash)"\
        --build-arg SERVICE=fusiond \
        --build-arg GIT_SHA=$commit_hash \
+       --build-arg VERSION=$version_tag \
        --target fusiond \
        -t ${ECR}fusiond:latest  \
        -t ${ECR}fusiond:$commit_hash_short  \


### PR DESCRIPTION
Fixes `fusiond info` command

Before
```
$ cd ./blockchain && make build
...
$ ./build/fusiond info
Version 0.0.0 (GitCommit 796302d6)
Compiled at 2024-01-15T18:39:28Z using Go go1.21.4 (amd64)
```

After 

```
$ cd ./blockchain && make build
...
$ ./build/fusiond info
Version fusiond@1.6.2-4-g796302d6 (GitCommit 796302d6)
Compiled at 2024-01-15 18:22:58 +0000 using Go go1.21.4 (amd64)
```