### PR TITLE
build: fix commit hash missing in binary version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 **/docker-compose.yml
 **/Dockerfile
-**/.git
 **/node_modules
 **/build
 **/dist

--- a/docker/Dockerfile-fusion-stack
+++ b/docker/Dockerfile-fusion-stack
@@ -71,7 +71,8 @@ WORKDIR /fusionchain
 COPY . .
 WORKDIR /fusionchain/blockchain
 ENV BUILD_TAGS=muslc LINK_STATICALLY=true
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=bind,source=.git,target=.git \
+    --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     make build
 FROM alpine:3.18.0 AS fusiond


### PR DESCRIPTION
Run `fusiond version --long` to check the binary version information. (Standard Cosmos SDK variables set in the Makefile when running `make build`)

These variables weren't set in docker images because the builder couldn't access git info.